### PR TITLE
fix: support streaming Responses LLM endpoint

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -749,7 +749,7 @@ async def button_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
             context.user_data["settings_waiting"] = {"type": "llm", "dashboard_id": dashboard_id}
             await edit_message_with_auto_delete(
                 query,
-                "请按三行发送 LLM 配置：\nbase_url\nmodel\napi_key\n\n例如：\nhttps://api.openai.com/v1\ngpt-4o-mini\nsk-...",
+                "请发送 LLM 配置：\nbase_url\nmodel\napi_key\nendpoint(可选：auto/responses/responses_stream/chat)\n\n例如：\nhttps://api.openai.com/v1\ngpt-4o-mini\nsk-...\nauto",
             )
             return
         await edit_message_with_auto_delete(query, "未知设置操作。")
@@ -1542,9 +1542,14 @@ async def settings_text_handler(update: Update, context: ContextTypes.DEFAULT_TY
         if len(parts) < 3:
             await update.message.reply_text("LLM 配置需要三行：base_url、model、api_key。")
             return
+        endpoint_mode = parts[3].lower() if len(parts) >= 4 else "auto"
+        if endpoint_mode not in {"auto", "responses", "responses_stream", "chat"}:
+            await update.message.reply_text("endpoint 只能是 auto、responses、responses_stream 或 chat。")
+            return
         await db.upsert_llm_config(
             update.effective_user.id,
             dashboard_id,
+            provider=endpoint_mode,
             base_url=parts[0],
             model=parts[1],
             api_key=parts[2],

--- a/llm_assistant.py
+++ b/llm_assistant.py
@@ -43,18 +43,44 @@ def deserialize_pending_execution(payload):
 
 
 class OpenAICompatibleClient:
-    def __init__(self, base_url, api_key, model, timeout=60):
-        import aiohttp
-
+    def __init__(self, base_url, api_key, model, timeout=60, api_mode="auto"):
         self.base_url = (base_url or "https://api.openai.com/v1").rstrip("/")
+        api_mode = (api_mode or "auto").lower()
+        if self.base_url.endswith("/responses"):
+            self.base_url = self.base_url[: -len("/responses")]
+            if api_mode == "auto":
+                api_mode = "responses"
+        elif self.base_url.endswith("/chat/completions"):
+            self.base_url = self.base_url[: -len("/chat/completions")]
+            if api_mode == "auto":
+                api_mode = "chat"
         self.api_key = api_key
         self.model = model
-        self.timeout = aiohttp.ClientTimeout(total=timeout)
+        self.timeout_seconds = timeout
+        self.api_mode = api_mode if api_mode in {"auto", "chat", "responses", "responses_stream"} else "auto"
 
     async def chat(self, messages, tools):
         import aiohttp
 
         headers = {"Authorization": f"Bearer {self.api_key}"}
+        timeout = aiohttp.ClientTimeout(total=self.timeout_seconds)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            if self.api_mode in {"responses", "responses_stream"}:
+                return await self.post_responses(
+                    session,
+                    headers,
+                    messages,
+                    tools,
+                    stream=self.api_mode == "responses_stream",
+                )
+            try:
+                return await self.post_chat_completions(session, headers, messages, tools)
+            except RuntimeError as exc:
+                if self.api_mode == "chat" or not self.should_retry_with_responses(exc):
+                    raise
+                return await self.post_responses(session, headers, messages, tools)
+
+    async def post_chat_completions(self, session, headers, messages, tools):
         payload = {
             "model": self.model,
             "messages": messages,
@@ -62,15 +88,202 @@ class OpenAICompatibleClient:
             "tool_choice": "auto",
             "temperature": 0.2,
         }
-        async with aiohttp.ClientSession(timeout=self.timeout) as session:
-            async with session.post(
-                f"{self.base_url}/chat/completions", json=payload, headers=headers
-            ) as resp:
-                data = await resp.json(content_type=None)
-                if resp.status >= 400:
-                    message = data.get("error", {}).get("message") if isinstance(data, dict) else None
-                    raise RuntimeError(message or f"LLM 请求失败: HTTP {resp.status}")
-                return data["choices"][0]["message"]
+        async with session.post(
+            f"{self.base_url}/chat/completions", json=payload, headers=headers
+        ) as resp:
+            data = await resp.json(content_type=None)
+            if resp.status >= 400:
+                message = data.get("error", {}).get("message") if isinstance(data, dict) else None
+                raise RuntimeError(message or f"LLM 请求失败: HTTP {resp.status}")
+            return data["choices"][0]["message"]
+
+    async def post_responses(self, session, headers, messages, tools, stream=None):
+        stream = self.api_mode == "responses_stream" if stream is None else stream
+        payload = self.build_responses_payload(messages, tools, stream=stream)
+        async with session.post(
+            f"{self.base_url}/responses", json=payload, headers=headers
+        ) as resp:
+            if stream and resp.status < 400:
+                return await self.parse_responses_stream(resp)
+            data = await resp.json(content_type=None)
+            if resp.status >= 400:
+                message = data.get("error", {}).get("message") if isinstance(data, dict) else None
+                if not stream and self.should_retry_with_streaming_responses(message):
+                    return await self.post_responses(
+                        session, headers, messages, tools, stream=True
+                    )
+                raise RuntimeError(message or f"LLM Responses 请求失败: HTTP {resp.status}")
+            return self.parse_responses_message(data)
+
+    def should_retry_with_responses(self, exc):
+        text = str(exc).lower()
+        return (
+            "chat/completions" in text
+            or "chat completions" in text
+            or "endpoint not supported" in text
+            or "/v1/chat/completions" in text
+        )
+
+    def should_retry_with_streaming_responses(self, message):
+        text = str(message or "").lower()
+        compact = re.sub(r"\s+", " ", text)
+        return (
+            "stream required" in compact
+            or "stream=true required" in compact
+            or "streaming required" in compact
+            or ("stream" in compact and "required" in compact)
+        )
+
+    def build_responses_payload(self, messages, tools, stream=None):
+        stream = self.api_mode == "responses_stream" if stream is None else stream
+        payload = {
+            "model": self.model,
+            "input": self.convert_messages_to_responses_input(messages),
+            "tools": self.convert_tools_to_responses(tools),
+            "tool_choice": "auto",
+            "temperature": 0.2,
+        }
+        if stream:
+            payload["stream"] = True
+        return payload
+
+    def convert_tools_to_responses(self, tools):
+        response_tools = []
+        for tool in tools:
+            function = tool.get("function") or {}
+            response_tools.append(
+                {
+                    "type": "function",
+                    "name": function.get("name"),
+                    "description": function.get("description", ""),
+                    "parameters": function.get("parameters", {"type": "object", "properties": {}}),
+                }
+            )
+        return response_tools
+
+    def convert_messages_to_responses_input(self, messages):
+        items = []
+        for message in messages:
+            role = message.get("role")
+            if role == "tool":
+                items.append(
+                    {
+                        "type": "function_call_output",
+                        "call_id": message.get("tool_call_id"),
+                        "output": message.get("content") or "",
+                    }
+                )
+                continue
+            tool_calls = message.get("tool_calls") or []
+            if tool_calls:
+                for call in tool_calls:
+                    function = call.get("function") or {}
+                    items.append(
+                        {
+                            "type": "function_call",
+                            "call_id": call.get("id"),
+                            "name": function.get("name"),
+                            "arguments": function.get("arguments") or "{}",
+                        }
+                    )
+                continue
+            content = message.get("content")
+            if content:
+                items.append({"role": role, "content": content})
+        return items
+
+    def parse_responses_message(self, data):
+        output = data.get("output") or []
+        tool_calls = []
+        text_parts = []
+        for item in output:
+            if item.get("type") == "function_call":
+                tool_calls.append(
+                    {
+                        "id": item.get("call_id") or item.get("id"),
+                        "type": "function",
+                        "function": {
+                            "name": item.get("name"),
+                            "arguments": item.get("arguments") or "{}",
+                        },
+                    }
+                )
+            elif item.get("type") == "message":
+                for content in item.get("content") or []:
+                    if content.get("type") in {"output_text", "text"}:
+                        text_parts.append(content.get("text") or "")
+        return {
+            "role": "assistant",
+            "content": "\n".join(part for part in text_parts if part),
+            "tool_calls": tool_calls,
+        }
+
+    async def parse_responses_stream(self, resp):
+        events = []
+        buffer = []
+        if hasattr(resp.content, "__aiter__"):
+            async for raw_line in resp.content:
+                self._consume_responses_stream_line(events, buffer, raw_line)
+        else:
+            for raw_line in resp.content:
+                self._consume_responses_stream_line(events, buffer, raw_line)
+        if buffer:
+            self._append_responses_stream_event(events, "\n".join(buffer))
+        return self.parse_responses_stream_events(events)
+
+    def _consume_responses_stream_line(self, events, buffer, raw_line):
+        line = raw_line.decode("utf-8", errors="replace") if isinstance(raw_line, bytes) else str(raw_line)
+        for part in line.splitlines():
+            part = part.strip()
+            if not part:
+                if buffer:
+                    self._append_responses_stream_event(events, "\n".join(buffer))
+                    buffer.clear()
+                continue
+            if part.startswith("data:"):
+                buffer.append(part[5:].strip())
+        if buffer and line.endswith("\n"):
+            self._append_responses_stream_event(events, "\n".join(buffer))
+            buffer.clear()
+
+    def _append_responses_stream_event(self, events, payload):
+        if not payload or payload == "[DONE]":
+            return
+        try:
+            events.append(json.loads(payload))
+        except json.JSONDecodeError:
+            return
+
+    def parse_responses_stream_events(self, events):
+        tool_calls = []
+        text_parts = []
+        for event in events:
+            event_type = event.get("type")
+            if event_type == "response.output_text.delta":
+                text_parts.append(event.get("delta") or "")
+                continue
+            if event_type == "response.output_item.done":
+                item = event.get("item") or {}
+                if item.get("type") == "function_call":
+                    tool_calls.append(
+                        {
+                            "id": item.get("call_id") or item.get("id"),
+                            "type": "function",
+                            "function": {
+                                "name": item.get("name"),
+                                "arguments": item.get("arguments") or "{}",
+                            },
+                        }
+                    )
+                elif item.get("type") == "message":
+                    for content in item.get("content") or []:
+                        if content.get("type") in {"output_text", "text"}:
+                            text_parts.append(content.get("text") or "")
+        return {
+            "role": "assistant",
+            "content": "".join(part for part in text_parts if part),
+            "tool_calls": tool_calls,
+        }
 
 
 class AssistantRuntime:
@@ -328,6 +541,7 @@ async def run_assistant_message(database, telegram_id, dashboard, api, llm_confi
         llm_config.get("base_url"),
         llm_config.get("api_key"),
         llm_config.get("model") or "gpt-4o-mini",
+        api_mode=llm_config.get("provider") or "auto",
     )
     messages = [
         {

--- a/tests/test_llm_assistant.py
+++ b/tests/test_llm_assistant.py
@@ -3,7 +3,9 @@ import asyncio
 
 from llm_assistant import (
     AssistantRuntime,
+    OpenAICompatibleClient,
     PendingExecution,
+    TOOLS,
     deserialize_pending_execution,
     heuristic_batch_plan,
     redact_secret,
@@ -137,6 +139,157 @@ class LLMAssistantTests(unittest.TestCase):
 
         self.assertIn("目标不唯一", result["error"])
         self.assertIsNone(runtime.pending_execution)
+
+    def test_responses_payload_converts_chat_tools_and_tool_outputs(self):
+        client = OpenAICompatibleClient(
+            "https://api.openai.com/v1", "sk-test", "gpt-test", api_mode="responses"
+        )
+        messages = [
+            {"role": "system", "content": "system prompt"},
+            {"role": "user", "content": "list servers"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {"name": "search_servers", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "name": "search_servers",
+                "content": '{"count":1}',
+            },
+        ]
+
+        payload = client.build_responses_payload(messages, TOOLS)
+
+        self.assertEqual(payload["model"], "gpt-test")
+        self.assertEqual(payload["tools"][0]["type"], "function")
+        self.assertIn("name", payload["tools"][0])
+        self.assertEqual(payload["input"][2]["type"], "function_call")
+        self.assertEqual(payload["input"][3]["type"], "function_call_output")
+
+    def test_streaming_responses_payload_sets_stream_true(self):
+        client = OpenAICompatibleClient(
+            "https://api.openai.com/v1", "sk-test", "gpt-test", api_mode="responses_stream"
+        )
+
+        payload = client.build_responses_payload([{"role": "user", "content": "hi"}], TOOLS)
+
+        self.assertTrue(payload["stream"])
+
+    def test_responses_output_normalizes_to_chat_message_shape(self):
+        client = OpenAICompatibleClient(
+            "https://api.openai.com/v1", "sk-test", "gpt-test", api_mode="responses"
+        )
+
+        message = client.parse_responses_message(
+            {
+                "output": [
+                    {
+                        "type": "function_call",
+                        "call_id": "call_1",
+                        "name": "search_servers",
+                        "arguments": '{"query":"hk"}',
+                    },
+                    {
+                        "type": "message",
+                        "content": [{"type": "output_text", "text": "ok"}],
+                    },
+                ]
+            }
+        )
+
+        self.assertEqual(message["content"], "ok")
+        self.assertEqual(message["tool_calls"][0]["id"], "call_1")
+        self.assertEqual(message["tool_calls"][0]["function"]["name"], "search_servers")
+
+    def test_responses_stream_events_normalize_to_chat_message_shape(self):
+        client = OpenAICompatibleClient(
+            "https://api.openai.com/v1", "sk-test", "gpt-test", api_mode="responses_stream"
+        )
+
+        message = client.parse_responses_stream_events(
+            [
+                {"type": "response.output_text.delta", "delta": "ok"},
+                {
+                    "type": "response.output_item.done",
+                    "item": {
+                        "type": "function_call",
+                        "call_id": "call_1",
+                        "name": "search_servers",
+                        "arguments": '{"query":"hk"}',
+                    },
+                },
+            ]
+        )
+
+        self.assertEqual(message["content"], "ok")
+        self.assertEqual(message["tool_calls"][0]["id"], "call_1")
+        self.assertEqual(message["tool_calls"][0]["function"]["name"], "search_servers")
+        self.assertEqual(message["tool_calls"][0]["function"]["arguments"], '{"query":"hk"}')
+
+    def test_responses_retries_with_stream_when_required(self):
+        client = OpenAICompatibleClient(
+            "https://api.openai.com/v1", "sk-test", "gpt-test", api_mode="auto"
+        )
+        posts = []
+
+        class Response:
+            def __init__(self, status, payload=None, lines=None):
+                self.status = status
+                self.payload = payload
+                self.content = lines or []
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def json(self, content_type=None):
+                return self.payload
+
+        class Session:
+            def post(self, url, json, headers):
+                posts.append(json)
+                if len(posts) == 1:
+                    return Response(
+                        400,
+                        {"error": {"message": "stream=true required for this endpoint"}},
+                    )
+                return Response(
+                    200,
+                    lines=[
+                        b'data: {"type":"response.output_text.delta","delta":"ok"}\n',
+                        b"data: [DONE]\n",
+                    ],
+                )
+
+        message = asyncio.run(
+            client.post_responses(
+                Session(),
+                {"Authorization": "Bearer sk-test"},
+                [{"role": "user", "content": "hi"}],
+                TOOLS,
+            )
+        )
+
+        self.assertNotIn("stream", posts[0])
+        self.assertTrue(posts[1]["stream"])
+        self.assertEqual(message["content"], "ok")
+
+    def test_responses_endpoint_base_url_is_normalized(self):
+        client = OpenAICompatibleClient(
+            "https://api.openai.com/v1/responses", "sk-test", "gpt-test"
+        )
+
+        self.assertEqual(client.base_url, "https://api.openai.com/v1")
+        self.assertEqual(client.api_mode, "responses")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Based on latest main after PR #13 merge. This does not reuse the old PR branch feature/api-token-mcp-llm-chat.