### PR TITLE
improve LLM MCP session experience

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -23,7 +23,7 @@ from telegram.ext import (
 from nezha_api import NezhaAPI
 from database import Database
 from llm_assistant import (
-    deserialize_pending_execution,
+    load_pending_execution_for_confirmation,
     redact_secret,
     run_assistant_message,
     serialize_pending_execution,
@@ -758,6 +758,10 @@ async def button_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     elif data.startswith("exec_cancel_"):
         await query.answer()
         execution_id = data.split("exec_cancel_", 1)[1]
+        row = await db.get_pending_execution(execution_id)
+        if not row or row["telegram_id"] != query.from_user.id:
+            await edit_message_with_auto_delete(query, "确认已过期或无权限。")
+            return
         await db.delete_pending_execution(execution_id)
         await edit_message_with_auto_delete(query, "操作已取消。")
         return
@@ -768,11 +772,13 @@ async def button_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
             return
         await query.answer()
         execution_id = data.split("exec_confirm_", 1)[1]
-        row = await db.get_pending_execution(execution_id)
-        if not row or row["telegram_id"] != query.from_user.id:
-            await edit_message_with_auto_delete(query, "确认已过期或无权限。")
+        loaded = await load_pending_execution_for_confirmation(
+            db, execution_id, query.from_user.id
+        )
+        if loaded.get("error"):
+            await edit_message_with_auto_delete(query, loaded["error"])
             return
-        pending = deserialize_pending_execution(row["payload"])
+        pending = loaded["pending"]
         dashboard_row = await db.get_dashboard(query.from_user.id, pending.dashboard_id)
         if not dashboard_row:
             await edit_message_with_auto_delete(query, "未找到面板绑定。")
@@ -1563,14 +1569,32 @@ async def chat_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text("请先使用 /bind 命令绑定您的账号。")
         return
     user_text = " ".join(context.args).strip()
+    message_thread_id = getattr(update.effective_message, "message_thread_id", None) or 0
+    chat_id = update.effective_chat.id
+    if user_text.lower() in {"reset", "重置", "清空", "clear"}:
+        await db.reset_llm_session(
+            update.effective_user.id, chat_id, message_thread_id, dashboard_row["id"]
+        )
+        await update.message.reply_text("已清空当前面板的 LLM 对话记忆和待确认命令。")
+        return
     if not user_text:
-        await update.message.reply_text("请在 /chat 后面写你的请求，例如：/chat 在 hk 分组执行 `apt-get update`")
+        await update.message.reply_text(
+            "请在 /chat 后面写你的请求，例如：/chat 在 hk 分组执行 `apt-get update`\n"
+            "清空记忆：/chat reset"
+        )
         return
     llm_config = await db.get_llm_config(update.effective_user.id, dashboard_row["id"])
     api = create_api(dashboard_row)
     try:
         result = await run_assistant_message(
-            db, update.effective_user.id, dashboard_row, api, llm_config, user_text
+            db,
+            update.effective_user.id,
+            dashboard_row,
+            api,
+            llm_config,
+            user_text,
+            chat_id=chat_id,
+            message_thread_id=message_thread_id,
         )
     except Exception as e:
         await update.message.reply_text(f"助手处理失败：{e}")

--- a/database.py
+++ b/database.py
@@ -1,4 +1,6 @@
 # database.py
+import json
+import time
 from pathlib import Path
 import aiosqlite
 
@@ -57,6 +59,18 @@ class Database:
                     dashboard_id INTEGER NOT NULL,
                     payload TEXT NOT NULL,
                     created_at INTEGER NOT NULL,
+                    FOREIGN KEY (dashboard_id) REFERENCES dashboards (id)
+                )
+            ''')
+            await db.execute('''
+                CREATE TABLE IF NOT EXISTS llm_sessions (
+                    telegram_id INTEGER NOT NULL,
+                    chat_id INTEGER NOT NULL,
+                    message_thread_id INTEGER NOT NULL DEFAULT 0,
+                    dashboard_id INTEGER NOT NULL,
+                    history_json TEXT NOT NULL,
+                    updated_at INTEGER NOT NULL,
+                    PRIMARY KEY (telegram_id, chat_id, message_thread_id, dashboard_id),
                     FOREIGN KEY (dashboard_id) REFERENCES dashboards (id)
                 )
             ''')
@@ -247,6 +261,61 @@ class Database:
             await db.execute('DELETE FROM pending_executions WHERE id = ?', (execution_id,))
             await db.commit()
 
+    async def get_llm_history(self, telegram_id, chat_id, message_thread_id, dashboard_id):
+        async with aiosqlite.connect(self.db_path) as db:
+            async with db.execute('''
+                SELECT history_json
+                FROM llm_sessions
+                WHERE telegram_id = ?
+                  AND chat_id = ?
+                  AND message_thread_id = ?
+                  AND dashboard_id = ?
+            ''', (telegram_id, chat_id, message_thread_id or 0, dashboard_id)) as cursor:
+                row = await cursor.fetchone()
+                if not row:
+                    return []
+                try:
+                    history = json.loads(row[0])
+                except (TypeError, json.JSONDecodeError):
+                    return []
+                return history if isinstance(history, list) else []
+
+    async def save_llm_history(self, telegram_id, chat_id, message_thread_id, dashboard_id, history):
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute('''
+                INSERT INTO llm_sessions (
+                    telegram_id, chat_id, message_thread_id, dashboard_id, history_json, updated_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(telegram_id, chat_id, message_thread_id, dashboard_id)
+                DO UPDATE SET
+                    history_json=excluded.history_json,
+                    updated_at=excluded.updated_at
+            ''', (
+                telegram_id,
+                chat_id,
+                message_thread_id or 0,
+                dashboard_id,
+                json.dumps(history or [], ensure_ascii=False, separators=(',', ':')),
+                int(time.time()),
+            ))
+            await db.commit()
+
+    async def reset_llm_session(self, telegram_id, chat_id, message_thread_id, dashboard_id):
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute('''
+                DELETE FROM llm_sessions
+                WHERE telegram_id = ?
+                  AND chat_id = ?
+                  AND message_thread_id = ?
+                  AND dashboard_id = ?
+            ''', (telegram_id, chat_id, message_thread_id or 0, dashboard_id))
+            await db.execute('''
+                DELETE FROM pending_executions
+                WHERE telegram_id = ? AND dashboard_id = ?
+            ''', (telegram_id, dashboard_id))
+            await db.commit()
+
     async def set_default_dashboard(self, telegram_id, dashboard_id):
         async with aiosqlite.connect(self.db_path) as db:
             await db.execute('''
@@ -274,6 +343,7 @@ class Database:
             ''', (dashboard_id, telegram_id))
             await db.execute('DELETE FROM llm_configs WHERE dashboard_id = ? AND telegram_id = ?', (dashboard_id, telegram_id))
             await db.execute('DELETE FROM pending_executions WHERE dashboard_id = ? AND telegram_id = ?', (dashboard_id, telegram_id))
+            await db.execute('DELETE FROM llm_sessions WHERE dashboard_id = ? AND telegram_id = ?', (dashboard_id, telegram_id))
             
             # 检查是否还有其他面板
             async with db.execute('''
@@ -305,6 +375,7 @@ class Database:
             await db.execute('DELETE FROM dashboards WHERE telegram_id = ?', (telegram_id,))
             await db.execute('DELETE FROM llm_configs WHERE telegram_id = ?', (telegram_id,))
             await db.execute('DELETE FROM pending_executions WHERE telegram_id = ?', (telegram_id,))
+            await db.execute('DELETE FROM llm_sessions WHERE telegram_id = ?', (telegram_id,))
             # 删除用户
             await db.execute('DELETE FROM users WHERE telegram_id = ?', (telegram_id,))
             await db.commit()

--- a/llm_assistant.py
+++ b/llm_assistant.py
@@ -3,7 +3,26 @@ import re
 import time
 from dataclasses import asdict, dataclass
 
-from server_utils import attach_group_ids, filter_servers, sort_servers_for_display
+from server_utils import (
+    attach_group_ids,
+    filter_servers,
+    server_is_online,
+    sort_servers_for_display,
+)
+
+
+HISTORY_LIMIT = 12
+
+SYSTEM_PROMPT = (
+    "你是 Nezha Telegram Bot 的运维助手。你可以查询服务器和分组。"
+    "不要推断服务器在线状态；必须使用 search_servers 返回的 explicit status、online、"
+    "online_count、offline_count 字段说明在线/离线。如果字段缺失或不一致，就说未知，"
+    "不要把未知说成离线。用户提到具体服务器 ID 或完整服务器名时，先用实时服务器列表确认目标，"
+    "再把明确的 server_ids 或 server_names 传给 prepare_batch_command。"
+    "不要把不明确的简称扩大成所有服务器。任何执行命令都只能调用 prepare_batch_command 准备预览，"
+    "绝不能直接执行。准备命令前要总结目标依据，确认目标来自哪个面板、哪些 ID/名称或哪个分组，"
+    "然后交给 Telegram 二次确认。优先用中文简洁回答。"
+)
 
 
 def redact_secret(value):
@@ -40,6 +59,45 @@ def serialize_pending_execution(pending):
 def deserialize_pending_execution(payload):
     data = json.loads(payload)
     return PendingExecution(**data)
+
+
+def normalize_server_summary(server):
+    online = server_is_online(server)
+    return {
+        "id": server.get("id"),
+        "name": server.get("name"),
+        "online": online,
+        "status": "online" if online else "offline",
+        "last_active": server.get("last_active"),
+    }
+
+
+def bounded_history(messages, limit=HISTORY_LIMIT):
+    cleaned = []
+    for message in messages or []:
+        role = message.get("role")
+        content = message.get("content")
+        if role in {"user", "assistant"} and isinstance(content, str) and content.strip():
+            cleaned.append({"role": role, "content": content.strip()[:4000]})
+    return cleaned[-limit:]
+
+
+async def load_pending_execution_for_confirmation(
+    database, execution_id, telegram_id, dashboard_id=None
+):
+    row = await database.get_pending_execution(execution_id)
+    if not row:
+        return {"error": "确认已过期或不存在。"}
+    if row["telegram_id"] != telegram_id:
+        return {"error": "确认已过期或无权限。"}
+    pending = deserialize_pending_execution(row["payload"])
+    if pending.owner_telegram_id != telegram_id:
+        return {"error": "确认已过期或无权限。"}
+    if row["dashboard_id"] != pending.dashboard_id:
+        return {"error": "确认记录面板不一致，已拒绝执行。"}
+    if dashboard_id is not None and int(dashboard_id) != int(pending.dashboard_id):
+        return {"error": "确认面板不匹配，已拒绝执行。"}
+    return {"row": row, "pending": pending}
 
 
 class OpenAICompatibleClient:
@@ -123,13 +181,14 @@ class AssistantRuntime:
             high_load=high_load,
             high_traffic=high_traffic,
         )
+        normalized = [normalize_server_summary(s) for s in result]
         return {
-            "servers": [
-                {"id": s.get("id"), "name": s.get("name"), "online": bool(s.get("_online"))}
-                for s in result
-            ],
+            "servers": normalized,
             "count": len(result),
+            "online_count": sum(1 for s in normalized if s["online"]),
+            "offline_count": sum(1 for s in normalized if not s["online"]),
             "source": source,
+            "status_basis": "last_active within threshold",
         }
 
     async def get_server_detail(self, server_id):
@@ -223,10 +282,7 @@ class AssistantRuntime:
             summaries.append(f"{name} -> {server.get('name')} (ID {server_id})")
 
         return {
-            "servers": [
-                {"id": s.get("id"), "name": s.get("name"), "online": bool(s.get("_online"))}
-                for s in selected.values()
-            ],
+            "servers": [normalize_server_summary(s) for s in selected.values()],
             "count": len(selected),
             "source": "explicit-targets",
             "match_summary": "\n".join(summaries),
@@ -261,7 +317,10 @@ TOOLS = [
         "type": "function",
         "function": {
             "name": "search_servers",
-            "description": "Search/filter servers by name, group name, status, high load, or high traffic.",
+            "description": (
+                "Search/filter servers and return explicit server status. Use online, status, "
+                "online_count, and offline_count exactly; do not infer status from missing fields."
+            ),
             "parameters": {
                 "type": "object",
                 "properties": {
@@ -314,8 +373,19 @@ TOOLS = [
 ]
 
 
-async def run_assistant_message(database, telegram_id, dashboard, api, llm_config, user_text):
+async def run_assistant_message(
+    database,
+    telegram_id,
+    dashboard,
+    api,
+    llm_config,
+    user_text,
+    chat_id=None,
+    message_thread_id=0,
+):
     runtime = AssistantRuntime(database, telegram_id, dashboard, api)
+    chat_id = int(chat_id if chat_id is not None else telegram_id)
+    message_thread_id = int(message_thread_id or 0)
     if not llm_config or not llm_config.get("api_key"):
         result = await heuristic_batch_plan(runtime, user_text)
         if isinstance(result, PendingExecution):
@@ -329,25 +399,28 @@ async def run_assistant_message(database, telegram_id, dashboard, api, llm_confi
         llm_config.get("api_key"),
         llm_config.get("model") or "gpt-4o-mini",
     )
-    messages = [
-        {
-            "role": "system",
-            "content": (
-                "你是 Nezha Telegram Bot 的运维助手。你可以查询服务器和分组。"
-                "用户提到具体服务器 ID 或完整服务器名时，先用实时服务器列表确认目标，"
-                "再把明确的 server_ids 或 server_names 传给 prepare_batch_command。"
-                "不要把不明确的简称扩大成所有服务器。"
-                "任何执行命令都只能调用 prepare_batch_command 准备预览，绝不能直接执行。"
-                "优先用中文简洁回答。"
-            ),
-        },
-        {"role": "user", "content": user_text},
-    ]
+    history = bounded_history(
+        await database.get_llm_history(
+            telegram_id, chat_id, message_thread_id, dashboard["id"]
+        )
+    )
+    messages = [{"role": "system", "content": SYSTEM_PROMPT}, *history]
+    messages.append({"role": "user", "content": user_text})
     for _ in range(5):
         message = await client.chat(messages, TOOLS)
         calls = message.get("tool_calls") or []
         if not calls:
-            return {"text": message.get("content") or "没有可展示的回复。"}
+            text = message.get("content") or "没有可展示的回复。"
+            await database.save_llm_history(
+                telegram_id,
+                chat_id,
+                message_thread_id,
+                dashboard["id"],
+                bounded_history(
+                    [*history, {"role": "user", "content": user_text}, {"role": "assistant", "content": text}]
+                ),
+            )
+            return {"text": text}
         messages.append(message)
         for call in calls:
             name = call.get("function", {}).get("name")
@@ -363,6 +436,25 @@ async def run_assistant_message(database, telegram_id, dashboard, api, llm_confi
                 }
             )
             if runtime.pending_execution:
+                await database.save_llm_history(
+                    telegram_id,
+                    chat_id,
+                    message_thread_id,
+                    dashboard["id"],
+                    bounded_history(
+                        [
+                            *history,
+                            {"role": "user", "content": user_text},
+                            {
+                                "role": "assistant",
+                                "content": (
+                                    f"已准备在 {runtime.pending_execution.dashboard_alias} "
+                                    f"执行 {runtime.pending_execution.command}，等待确认。"
+                                ),
+                            },
+                        ]
+                    ),
+                )
                 return {"pending_execution": runtime.pending_execution}
     return {"text": "助手工具调用次数过多，请缩小目标范围后再试。"}
 

--- a/tests/test_database_migration.py
+++ b/tests/test_database_migration.py
@@ -97,6 +97,77 @@ class DatabaseMigrationTests(unittest.TestCase):
             self.assertEqual(dashboard["username"], "alice")
             self.assertEqual(dashboard["api_token"], "nzp_parallel_secret")
 
+    def test_llm_history_is_isolated_by_user_chat_thread_and_dashboard(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = str(Path(tmp) / "users.db")
+            database = Database(db_path)
+            asyncio.run(database.initialize())
+
+            asyncio.run(
+                database.save_llm_history(
+                    42,
+                    1001,
+                    0,
+                    7,
+                    [{"role": "user", "content": "dashboard 7"}],
+                )
+            )
+            asyncio.run(
+                database.save_llm_history(
+                    42,
+                    1001,
+                    0,
+                    8,
+                    [{"role": "user", "content": "dashboard 8"}],
+                )
+            )
+            asyncio.run(
+                database.save_llm_history(
+                    43,
+                    1001,
+                    0,
+                    7,
+                    [{"role": "user", "content": "other user"}],
+                )
+            )
+
+            self.assertEqual(
+                asyncio.run(database.get_llm_history(42, 1001, 0, 7))[0]["content"],
+                "dashboard 7",
+            )
+            self.assertEqual(
+                asyncio.run(database.get_llm_history(42, 1001, 0, 8))[0]["content"],
+                "dashboard 8",
+            )
+            self.assertEqual(
+                asyncio.run(database.get_llm_history(43, 1001, 0, 7))[0]["content"],
+                "other user",
+            )
+
+    def test_reset_llm_session_clears_history_and_pending_for_scope(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = str(Path(tmp) / "users.db")
+            database = Database(db_path)
+            asyncio.run(database.initialize())
+
+            asyncio.run(
+                database.save_llm_history(
+                    42,
+                    1001,
+                    0,
+                    7,
+                    [{"role": "user", "content": "forget me"}],
+                )
+            )
+            asyncio.run(database.save_pending_execution("same", 42, 7, "{}", 1))
+            asyncio.run(database.save_pending_execution("other", 42, 8, "{}", 1))
+
+            asyncio.run(database.reset_llm_session(42, 1001, 0, 7))
+
+            self.assertEqual(asyncio.run(database.get_llm_history(42, 1001, 0, 7)), [])
+            self.assertIsNone(asyncio.run(database.get_pending_execution("same")))
+            self.assertIsNotNone(asyncio.run(database.get_pending_execution("other")))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_llm_assistant.py
+++ b/tests/test_llm_assistant.py
@@ -3,11 +3,14 @@ import asyncio
 
 from llm_assistant import (
     AssistantRuntime,
+    SYSTEM_PROMPT,
     PendingExecution,
     deserialize_pending_execution,
     heuristic_batch_plan,
+    load_pending_execution_for_confirmation,
     redact_secret,
     serialize_pending_execution,
+    TOOLS,
 )
 
 
@@ -137,6 +140,81 @@ class LLMAssistantTests(unittest.TestCase):
 
         self.assertIn("目标不唯一", result["error"])
         self.assertIsNone(runtime.pending_execution)
+
+    def test_search_servers_reports_online_from_last_active(self):
+        from datetime import datetime, timedelta, timezone
+
+        class API:
+            async def get_servers(self):
+                return {
+                    "success": True,
+                    "data": [
+                        {
+                            "id": 11,
+                            "name": "hk-web-1",
+                            "last_active": (
+                                datetime.now(timezone.utc) - timedelta(seconds=2)
+                            ).isoformat(),
+                        }
+                    ],
+                }
+
+            async def get_server_groups(self):
+                return {"success": True, "data": []}
+
+        runtime = AssistantRuntime(
+            database=None,
+            telegram_id=42,
+            dashboard={"id": 7, "alias": "MAIN", "api_token": "nzp_secret"},
+            api=API(),
+        )
+
+        result = asyncio.run(runtime.search_servers(status="all"))
+
+        self.assertEqual(result["online_count"], 1)
+        self.assertEqual(result["offline_count"], 0)
+        self.assertIs(result["servers"][0]["online"], True)
+        self.assertEqual(result["servers"][0]["status"], "online")
+
+    def test_system_prompt_and_tool_schema_constrain_status_accuracy(self):
+        tool_text = str(TOOLS)
+
+        self.assertIn("不要推断服务器在线状态", SYSTEM_PROMPT)
+        self.assertIn("online_count", tool_text)
+        self.assertIn("offline_count", tool_text)
+
+    def test_pending_confirmation_rejects_wrong_user_or_dashboard(self):
+        pending = PendingExecution(
+            owner_telegram_id=42,
+            dashboard_id=7,
+            dashboard_alias="MAIN",
+            command="uptime",
+            server_ids=[11],
+            server_names=["hk-web-1"],
+            source="explicit-targets",
+        )
+
+        class DB:
+            async def get_pending_execution(self, execution_id):
+                return {
+                    "id": execution_id,
+                    "telegram_id": 42,
+                    "dashboard_id": 7,
+                    "payload": serialize_pending_execution(pending),
+                    "created_at": pending.created_at,
+                }
+
+        ok = asyncio.run(load_pending_execution_for_confirmation(DB(), "abc", 42, 7))
+        wrong_user = asyncio.run(
+            load_pending_execution_for_confirmation(DB(), "abc", 99, 7)
+        )
+        wrong_dashboard = asyncio.run(
+            load_pending_execution_for_confirmation(DB(), "abc", 42, 8)
+        )
+
+        self.assertIsInstance(ok["pending"], PendingExecution)
+        self.assertIn("无权限", wrong_user["error"])
+        self.assertIn("面板", wrong_dashboard["error"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Design summary
- Make server status explicit in LLM tool results so online/offline counts come from normalized fields instead of model inference.
- Add a stronger assistant system prompt around status accuracy, target selection, and command confirmation.
- Add bounded LLM conversation memory scoped by Telegram user, chat, topic/thread, and dashboard.
- Add /chat reset and /llm reset behavior for the active user/dashboard scope.
- Validate pending command confirmations by stored plan owner and dashboard before execution.

## Implemented pieces
- Fixed the false-offline bug caused by returning bool(_online) even though _online was never populated.
- Added llm_sessions storage with get/save/reset helpers.
- Stored short assistant history after normal responses and pending command previews.
- Routed confirmation through load_pending_execution_for_confirmation and tightened cancel ownership.
- Added focused tests for status normalization, prompt/tool status constraints, memory isolation, reset, and confirmation rejection.

## Known follow-ups
- Dashboard selection for /chat still uses the current default dashboard; a later UX pass could add explicit /chat dashboard selection.
- Pending execution storage is dashboard/user scoped; chat/thread scoping could be added if command confirmations are ever allowed outside private chat.
- The heuristic fallback remains intentionally simple when no LLM API key is configured.

## Verification
- python3 -m compileall bot.py llm_assistant.py database.py server_utils.py nezha_api.py
- python3 -m unittest discover (base interpreter: OK, dependency-gated tests skipped)
- /tmp/nezha-llm-test-venv/bin/python -m unittest discover (26 tests OK)
- git diff --check